### PR TITLE
replace obsolete default-tab-width with tab-width

### DIFF
--- a/graphviz-dot-mode.el
+++ b/graphviz-dot-mode.el
@@ -197,7 +197,7 @@ the command."
   :type 'boolean
   :group 'graphviz)
 
-(defcustom graphviz-dot-indent-width default-tab-width
+(defcustom graphviz-dot-indent-width tab-width
   "*Indentation width in Graphviz Dot mode buffers."
   :type 'integer
   :group 'graphviz)


### PR DESCRIPTION
https://www.gnu.org/software/emacs/manual/html_node/efaq/Changing-the-length-of-a-Tab.html